### PR TITLE
Rev japac to use 1.0.1 which fixes tag version

### DIFF
--- a/emea-platforms/main.tf
+++ b/emea-platforms/main.tf
@@ -37,7 +37,7 @@ module "argo_rollouts" {
 
 
 module "release_agent" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.0.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.0.1"
 
   release_agent_token = var.rt_token
 

--- a/japac-platforms/main.tf
+++ b/japac-platforms/main.tf
@@ -32,7 +32,7 @@ module "argo_rollouts" {
 }
 
 module "release_agent" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.0.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.0.1"
 
   release_agent_token = var.rt_token
 

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -37,7 +37,7 @@ module "argo_rollouts" {
 
 
 module "release_agent" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.0.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.0.1"
 
   release_agent_token = var.rt_token
 


### PR DESCRIPTION
Old process relied on manual step to replace tag in values or pull fomr chart, I just force it to match chart version.