### PR TITLE
use new FE team role

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -28,7 +28,7 @@ parameters:
     default: cera-fe-operator
   aws-sso-assumed-role:
     type: string
-    default: AWSReservedSSO_devops-ce-0034ed37_ea6f69cdd6bb1a5d 
+    default: AWSReservedSSO_field-engineering-0034ed37_2554f11f982db0cc
     description: The assigned role from IT when users login via SSO.
   root-domain-name:
     type: string


### PR DESCRIPTION
CHanges the underlying assume / trust relationship to use the newly created FE only SSO role.

This affects how operators access CERA cluster.

#### Suggest .aws/config

```yaml
[profile operator]
# The FE specific role grants elevated rights and owns CERA stack
role_arn = arn:aws:iam::992382483259:role/cera-fe-operator-role
role_session_name = FE_Pipeline_Session
region = us-west-2
sso_start_url = https://circleci.awsapps.com/start
sso_region = us-east-1
# We assume this role through the primary role (via a trust policy)
source_profile = field

[profile field]
# The 'priamry' role is the one access via SSO, same as console role.
sso_start_url = https://circleci.awsapps.com/start
sso_region = us-east-1
sso_account_id = 992382483259
# Can login directly to this role provided by IT.
sso_role_name = field-engineering-0034ed37
region = us-east-2
output = json
credential_process = aws-vault exec --json
```