### PR TITLE
Add Rootlanding

### DIFF
--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.5"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.6"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.2"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.3"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.1"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.2"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.3"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.4"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.6"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.7"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.4"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.5"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.8"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.9"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id

--- a/namer-eks/main.tf
+++ b/namer-eks/main.tf
@@ -33,7 +33,7 @@ module "regional_dns" {
 # A bit odd to see istio here, but it includes cert-manager whcih interacts with KMS and Istio creates ELBs 
 # that will prevent this plan from destorying cluster (AWS blocks delete since networkinterface is attached)
 module "helm_istio" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.7"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-istio.git?ref=8.0.8"
 
   aws_region                = data.aws_region.current.name
   aws_account_no            = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
This makes several changes to Istio module noted in FE-81.

- Add new A record with weighted load balanace and healthchecks for root domain
- Add new global gateway to each region to handle root domain
- new cert and update existing certissuer ^^^

Fieldguide is now placeholder (via a temp redirect)

```shell
$ curl -IL "http://circleci-fieldeng.com/"
HTTP/1.1 301 Moved Permanently
location: https://circleci-fieldeng.com/
date: Tue, 17 Sep 2024 13:14:10 GMT
server: istio-envoy
transfer-encoding: chunked

HTTP/2 302 
location: https://fieldguide.circleci-fieldeng.com/
server: istio-envoy
date: Tue, 17 Sep 2024 13:14:11 GMT
x-envoy-upstream-service-time: 1

HTTP/2 200 
accept-ranges: bytes
content-length: 1124566
content-type: text/html; charset=utf-8
etag: "sjyjkfo3py"
last-modified: Tue, 17 Sep 2024 12:48:15 GMT
server: istio-envoy
date: Tue, 17 Sep 2024 13:14:11 GMT
x-envoy-upstream-service-time: 1
```