### PR TITLE
break CCI Release Agent into Dev and Prod

### DIFF
--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -43,7 +43,18 @@ module "release_agent" {
 
   release_agent_token = var.rt_token
 
-  managed_namespaces = ["default", "guidebook", "guidebook-dev", "boa", "boa-dev", "circleci-release-agent-system", "dr-demo", "eddies-demo"]
+  managed_namespaces = ["default", "guidebook",  "boa", "circleci-release-agent-system", "dr-demo", "eddies-demo"]
+
+  depends_on = [module.argo_rollouts]
+}
+
+
+module "release_agent" {
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.2.0"
+
+  release_agent_token = var.rt_token
+
+  managed_namespaces = [ "guidebook-dev",  "boa-dev", ]
 
   depends_on = [module.argo_rollouts]
 }

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -56,5 +56,7 @@ module "release_agent_dev" {
 
   managed_namespaces = ["guidebook-dev", "boa-dev", ]
 
+  namespace = "circleci-release-agent-system-dev"
+
   depends_on = [module.argo_rollouts]
 }

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -39,7 +39,7 @@ module "argo_rollouts" {
 
 
 module "release_agent" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.3.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.3.1"
 
   release_agent_token = var.rt_token
 
@@ -50,7 +50,7 @@ module "release_agent" {
 
 
 module "release_agent_dev" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.3.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.3.1"
 
   release_agent_token = var.rt_token_dev
 

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -49,10 +49,10 @@ module "release_agent" {
 }
 
 
-module "release_agent" {
+module "release_agent_dev" {
   source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.2.0"
 
-  release_agent_token = var.rt_token
+  release_agent_token = var.rt_token_dev
 
   managed_namespaces = [ "guidebook-dev",  "boa-dev", ]
 

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -39,7 +39,7 @@ module "argo_rollouts" {
 
 
 module "release_agent" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.2.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.3.0"
 
   release_agent_token = var.rt_token
 
@@ -50,13 +50,13 @@ module "release_agent" {
 
 
 module "release_agent_dev" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.2.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-helm-cci-release-agent?ref=1.3.0"
 
   release_agent_token = var.rt_token_dev
 
   managed_namespaces = ["guidebook-dev", "boa-dev", ]
 
-  namespace = "circleci-release-agent-system-dev"
+  environment_suffix = "-dev"
 
   depends_on = [module.argo_rollouts]
 }

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -43,7 +43,7 @@ module "release_agent" {
 
   release_agent_token = var.rt_token
 
-  managed_namespaces = ["default", "guidebook",  "boa", "circleci-release-agent-system", "dr-demo", "eddies-demo"]
+  managed_namespaces = ["default", "guidebook", "boa", "circleci-release-agent-system", "dr-demo", "eddies-demo"]
 
   depends_on = [module.argo_rollouts]
 }
@@ -54,7 +54,7 @@ module "release_agent_dev" {
 
   release_agent_token = var.rt_token_dev
 
-  managed_namespaces = [ "guidebook-dev",  "boa-dev", ]
+  managed_namespaces = ["guidebook-dev", "boa-dev", ]
 
   depends_on = [module.argo_rollouts]
 }

--- a/namer-platforms/variables.tf
+++ b/namer-platforms/variables.tf
@@ -7,6 +7,14 @@ variable "rt_token" {
   sensitive   = true
 }
 
+
+variable "rt_token_dev" {
+  description = "RT_TOKEN to deploy CCI Release agent to, can be exposed by setting TF_VAR_rt_token prior to runnning TF."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "nexus_admin_password" {
   description = "Found in 1password, global nexus adminpassword, can be exposed by setting TF_VAR_nexus_admin_password prior to runnning TF."
   type        = string


### PR DESCRIPTION
This adds new variable (added to contexts) to add an `rt_token_dev` to the variables used by final job. 

We then make two calls to the release Agent module, passing mutually exclusive namespaces to monitor.