### PR TITLE
create new FE Utilities namespace

### DIFF
--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -8,7 +8,7 @@ locals {
 
 
 module "vault_config" {
-  source = "git@github.com:AwesomeCICD/ceratf-module-vault-config?ref=1.13.0"
+  source = "git@github.com:AwesomeCICD/ceratf-module-vault-config?ref=1.14.0"
 }
 
 
@@ -28,7 +28,7 @@ module "nexus_config" {
 
 
 module "app_spaces" {
-  source           = "git@github.com:AwesomeCICD/ceratf-module-appspaces?ref=3.4.0"
+  source           = "git@github.com:AwesomeCICD/ceratf-module-appspaces?ref=3.5.0"
   cluster_endpoint = data.terraform_remote_state.ceratf_regional.outputs.cluster_endpoint
   cluster_name     = data.terraform_remote_state.ceratf_regional.outputs.cluster_name
 }


### PR DESCRIPTION
Pulls in Appspaces 3.5.0 and Vault COnfig 1.14.0, both of which support a new `fe-utilities` namespace needed to publish new datasync app from FE-198