### PR TITLE
Add Grafana host to Istio subdomains gateway

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -78,11 +78,7 @@ tf_job_defaults: &tf_job_defaults
 jobs:
   do_nothing:
     #a quirk in our rules only allow downstream jobs to run if at least 1 upstream requires is present.
-    resource_class: small
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - run: echo "Nothing to see here, move along."
+    type: no-op
 
   apply_module:
     environment:

--- a/namer-platforms/files/circleci-platform-health.json
+++ b/namer-platforms/files/circleci-platform-health.json
@@ -37,7 +37,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -86,7 +86,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -101,7 +101,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -151,7 +151,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -166,7 +166,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -216,7 +216,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -231,7 +231,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -281,7 +281,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -296,7 +296,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -346,7 +346,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -361,7 +361,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -411,7 +411,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -440,7 +440,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -520,7 +520,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -535,7 +535,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -640,7 +640,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -668,7 +668,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -728,7 +728,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -743,7 +743,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -803,7 +803,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -831,7 +831,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -915,7 +915,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -930,7 +930,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1011,7 +1011,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1026,7 +1026,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1076,7 +1076,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1091,7 +1091,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1151,7 +1151,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1166,7 +1166,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1226,7 +1226,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1254,7 +1254,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1335,7 +1335,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1350,7 +1350,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1431,7 +1431,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1459,7 +1459,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1509,7 +1509,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1524,7 +1524,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1574,7 +1574,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1589,7 +1589,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1732,7 +1732,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1760,7 +1760,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1840,7 +1840,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1855,7 +1855,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1902,7 +1902,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",
@@ -1917,7 +1917,7 @@
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
-        "uid": "circleci-pg-ds"
+        "uid": "P66BDC2B81169D854"
       },
       "fieldConfig": {
         "defaults": {
@@ -1964,7 +1964,7 @@
           "dataset": "circleci_usage",
           "datasource": {
             "type": "grafana-postgresql-datasource",
-            "uid": "circleci-pg-ds"
+            "uid": "P66BDC2B81169D854"
           },
           "editorMode": "code",
           "format": "table",

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -106,6 +106,7 @@ module "grafana" {
         datasources = [
           {
             name      = "circleci-pg-ds"
+            uid       = "circleci-pg-ds"
             type      = "postgres"
             url       = "circleci-usage-pg-postgresql.monitoring.svc.cluster.local:5432"
             database  = "circleci_usage"

--- a/namer-platforms/main.tf
+++ b/namer-platforms/main.tf
@@ -209,7 +209,58 @@ resource "kubernetes_config_map" "circleci_dashboard" {
 }
 
 ###############################################################################
-# Istio VirtualService for Grafana (no nginx ingress controller in CERA)
+# Istio Gateway: add grafana host to the shared subdomains gateway
+# The gateway is not otherwise managed in Terraform — this resource imports
+# the full current spec and appends the grafana host.
+###############################################################################
+
+resource "kubectl_manifest" "grafana_gateway_host" {
+  yaml_body = <<-YAML
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: namer-istio-gateway-subdomains
+      namespace: istio-ingress
+    spec:
+      selector:
+        istio: ingressgateway
+      servers:
+        - hosts:
+            - "*.nexus.namer.circleci-fieldeng.com"
+            - "nexus.namer.circleci-fieldeng.com"
+            - "*.demo.namer.circleci-fieldeng.com"
+            - "*.dev.namer.circleci-fieldeng.com"
+            - "dev.namer.circleci-fieldeng.com"
+            - "vault.namer.circleci-fieldeng.com"
+            - "monitor.namer.circleci-fieldeng.com"
+            - "grafana.${data.terraform_remote_state.ceratf_regional.outputs.target_domain}"
+          port:
+            name: http
+            number: 80
+            protocol: HTTP
+          tls:
+            httpsRedirect: true
+        - hosts:
+            - "*.nexus.namer.circleci-fieldeng.com"
+            - "nexus.namer.circleci-fieldeng.com"
+            - "*.demo.namer.circleci-fieldeng.com"
+            - "*.dev.namer.circleci-fieldeng.com"
+            - "dev.namer.circleci-fieldeng.com"
+            - "vault.namer.circleci-fieldeng.com"
+            - "monitor.namer.circleci-fieldeng.com"
+            - "grafana.${data.terraform_remote_state.ceratf_regional.outputs.target_domain}"
+          port:
+            name: https
+            number: 443
+            protocol: HTTPS
+          tls:
+            credentialName: namer-circleci-fieldeng-com-subdomains
+            mode: SIMPLE
+  YAML
+}
+
+###############################################################################
+# Istio VirtualService for Grafana
 ###############################################################################
 
 resource "kubectl_manifest" "grafana_virtualservice" {


### PR DESCRIPTION
## Summary
- The `namer-istio-gateway-subdomains` Gateway has an explicit host allowlist — `grafana.namer.circleci-fieldeng.com` was missing, causing TLS handshake failures (`PR_END_OF_FILE_ERROR`)
- Manages the full gateway spec as a `kubectl_manifest` so the host list stays in Terraform going forward
- Already patched live via `kubectl patch` — this codifies it

## Test plan
- [ ] `https://grafana.namer.circleci-fieldeng.com` continues to load after apply
- [ ] `terraform plan` shows no unexpected changes to the gateway

Made with [Cursor](https://cursor.com)