### PR TITLE
Pin nexus provider to 2.3.0 to fix Empty Summary bug

### DIFF
--- a/namer-platforms/versions.tf
+++ b/namer-platforms/versions.tf
@@ -11,7 +11,8 @@ terraform {
     }
 
     nexus = {
-      source = "datadrivers/nexus"
+      source  = "datadrivers/nexus"
+      version = "2.3.0"
     }
   }
 


### PR DESCRIPTION
## Summary
- Pins the `datadrivers/nexus` Terraform provider to `2.3.0` in `namer-platforms/versions.tf`
- The provider was previously unpinned, pulling the latest version (`2.7.0`) on each CI run
- The `nexus_script` resource's Read function in newer versions returns a malformed diagnostic (`Error: Empty Summary`) when refreshing state for the timestamp-named cleanup policy script, blocking **all** Terraform applies in `namer-platforms`

## Root Cause
The `ceratf-module-nexus-config@0.4.0` module uses `timestamp()` in the `nexus_script.cleanup_policy_create` name, forcing recreation every apply. When the provider refreshes the old timestamped resource, it fails with "Empty Summary: This is always a bug in the provider."

## Test plan
- [ ] Verify the NAMER Platform IaC job passes on this branch
- [ ] Merge to main and confirm the pipeline completes successfully

Made with [Cursor](https://cursor.com)